### PR TITLE
Fix return statements and database path

### DIFF
--- a/Model/RubiksCube.cpp
+++ b/Model/RubiksCube.cpp
@@ -19,6 +19,8 @@ char RubiksCube::getColorLetter(COLOR color) {
             return 'W';
         case COLOR::ORANGE:
             return 'O';
+        default:
+            return '?';
     }
 }
 
@@ -63,6 +65,8 @@ string RubiksCube::getMove(MOVE ind) {
             return "B'";
         case MOVE::B2:
             return "B2";
+        default:
+            return "";
     }
 }
 
@@ -107,6 +111,8 @@ RubiksCube &RubiksCube::move(MOVE ind) {
             return this->bPrime();
         case MOVE::B2:
             return this->b2();
+        default:
+            return *this;
     }
 }
 
@@ -151,6 +157,8 @@ RubiksCube &RubiksCube::invert(MOVE ind) {
             return this->b();
         case MOVE::B2:
             return this->b2();
+        default:
+            return *this;
     }
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -261,7 +261,7 @@ int main() {
 
 
 // CornerDBMaker Testing --------------------------------------------------------------------------
-    string fileName = "C:\\Users\\user\\CLionProjects\\rubiks-cube-solver\\Databases\\cornerDepth5V1.txt";
+    string fileName = "Databases/cornerDepth5V1.txt";
 
 //    Code to create Corner Database
 //    CornerDBMaker dbMaker(fileName, 0x99);


### PR DESCRIPTION
## Summary
- address compiler warnings by adding default return branches in `RubiksCube.cpp`
- use a relative path for the corner pattern database in `main.cpp`

## Testing
- `cmake ..`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_68851043db00832795d0d8989f4537cb